### PR TITLE
fixed issue of passing empty parameter list to optimizer

### DIFF
--- a/word2vec/trainer.py
+++ b/word2vec/trainer.py
@@ -34,7 +34,7 @@ class Word2VecTrainer:
         for iteration in range(self.iterations):
 
             print("\n\n\nIteration: " + str(iteration + 1))
-            optimizer = optim.SparseAdam(self.skip_gram_model.parameters(), lr=self.initial_lr)
+            optimizer = optim.SparseAdam(list(self.skip_gram_model.parameters()), lr=self.initial_lr)
             scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, len(self.dataloader))
 
             running_loss = 0.0


### PR DESCRIPTION
Hi @Andras7, first I want to thank you for providing this code, it really is a big help. I ran into this error when trying to train the model:

Traceback (most recent call last):
  File "/path/to/test.py", line 8, in <module>
    w2v_trainer.train()
  File "/path/to/venv/lib/python3.8/site-packages/word2vec/trainer.py", line 37, in train
    optimizer = optim.SparseAdam(self.skip_gram_model.parameters(), lr=self.initial_lr)
  File "/path/to/venv/lib/python3.8/site-packages/torch/optim/sparse_adam.py", line 49, in __init__
    super(SparseAdam, self).__init__(params, defaults)
  File "/path/to/venv/lib/python3.8/site-packages/torch/optim/optimizer.py", line 47, in __init__
    raise ValueError("optimizer got an empty parameter list")
ValueError: optimizer got an empty parameter list

So I went ahead and wrapped self.skip_gram_model.parameters() in list().
Might this be a version issue? I ran it with python=3.8, torch=1.7.1

Works for me now, hope this is fine with you? Feel free to accept the PR.